### PR TITLE
pairing: Show instance description and Public URI

### DIFF
--- a/source/avalanche/web/package.d
+++ b/source/avalanche/web/package.d
@@ -17,18 +17,19 @@ module avalanche.web;
 
 import vibe.d;
 
-import moss.service.tokens.manager;
-import moss.core.memoryinfo;
-import moss.service.accounts;
-import moss.service.tokens;
-import moss.service.tokens.manager;
+import avalanche.models.settings;
 import avalanche.web.accounts;
-import moss.db.keyvalue;
+import moss.core.memoryinfo;
 import moss.db.keyvalue.orm;
+import moss.db.keyvalue;
+import moss.service.accounts;
+import moss.service.context;
 import moss.service.interfaces;
 import moss.service.models.bearertoken;
 import moss.service.models.endpoints;
-import moss.service.context;
+import moss.service.tokens.manager;
+import moss.service.tokens.manager;
+import moss.service.tokens;
 
 /**
  * Core entry into the Avalanche Web UI
@@ -66,7 +67,8 @@ import moss.service.context;
     @noAuth void index() @safe
     {
         immutable publicKey = context.tokenManager.publicKey;
-        render!("index.dt", publicKey, totalRam);
+        const settings = context.appDB.getSettings().tryMatch!((Settings s) => s);
+        render!("index.dt", publicKey, settings, totalRam);
     }
 
     /**

--- a/views/widgets/pairing.dt
+++ b/views/widgets/pairing.dt
@@ -3,6 +3,8 @@ div.col-8.col-sm-8.col-lg-8
         div.card-header
             h3.card-title Connections
         div.card-body
-            p To pair this builder with Summit, you'll need this public key
-            pre #{publicKey}
+            h4 Public URI for this builder (<i>#{settings.instanceDescription}</i>)
+            p <code>#{settings.instanceURI}</code>
+            h4 To pair this builder with Summit, you'll need this public key
+            p <code>#{publicKey}</code>
             div.list-group.list-group-flush#connectionList


### PR DESCRIPTION
Simple tweak to make it easier to check the description and public URI for any given Avalanche builder.

Additionally, make it easier to copy the publicKey by switching to <code></code> tags.